### PR TITLE
Replace URLEncoder with URI encode for CreateOrUpdateResult

### DIFF
--- a/src/main/java/com/force/api/ForceApi.java
+++ b/src/main/java/com/force/api/ForceApi.java
@@ -18,6 +18,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -272,7 +273,7 @@ public class ForceApi {
 			// See createSObject for note on streaming ambition
 			HttpResponse res =
 				apiRequest(new HttpRequest()
-					.url(uriBase()+"/sobjects/"+type+"/"+externalIdField+"/"+URI(null, externalIdValue, null).toString()+"?_HttpMethod=PATCH")
+					.url(uriBase()+"/sobjects/"+type+"/"+externalIdField+"/"+new URI(null, externalIdValue, null).toString()+"?_HttpMethod=PATCH")
 					.method("POST")
 					.header("Accept", "application/json")
 					.header("Content-Type", "application/json")
@@ -307,6 +308,8 @@ public class ForceApi {
 		} catch (JsonMappingException e) {
 			throw new ResourceException(e);
 		} catch (IOException e) {
+			throw new ResourceException(e);
+		} catch(URISyntaxException e) {
 			throw new ResourceException(e);
 		}
 	}

--- a/src/main/java/com/force/api/ForceApi.java
+++ b/src/main/java/com/force/api/ForceApi.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -271,7 +272,7 @@ public class ForceApi {
 			// See createSObject for note on streaming ambition
 			HttpResponse res =
 				apiRequest(new HttpRequest()
-					.url(uriBase()+"/sobjects/"+type+"/"+externalIdField+"/"+URLEncoder.encode(externalIdValue,"UTF-8")+"?_HttpMethod=PATCH")
+					.url(uriBase()+"/sobjects/"+type+"/"+externalIdField+"/"+URI(null, externalIdValue, null).toString()+"?_HttpMethod=PATCH")
 					.method("POST")
 					.header("Accept", "application/json")
 					.header("Content-Type", "application/json")


### PR DESCRIPTION
While using this library in one of our production environments, we found a strange issue with upserts when the external_id contains spaces (e.g. "Hello World"). This was showing up as "Hello+World" instead "Hello World" on Salesforce.
I believe [this](https://github.com/jesperfj/force-rest-api/blob/dc78168aa1494ca8baeed7573db5d00eb7dd6cb7/src/main/java/com/force/api/ForceApi.java#L274) is the source of the problem. The external_id supplied to the`createOrUpdateSObject`  method is used to build a URL. The library does a form encode (`URLEncoder.encode`) of the external_id instead of a URI encode (i.e. [RFC 2396](https://www.ietf.org/rfc/rfc2396.html#section-2.4.1) and [RFC 3986](https://www.ietf.org/rfc/rfc3986.html#section-2.1) style encodes for space character).

form-encode(“Hello World”) → “Hello+World”

uri-encode(“Hello World”) → “Hello%20World”

[Here](https://github.com/restforce/restforce/blob/eaf43cfbd8a92698e37057ab24fa711701a8d374/lib/restforce/concerns/api.rb#L383) is relevant code from restforce api (ruby gem). It uses a uri-encode format. 

Encoding the external_id before passing it to the ForceApi library will not help because it will be equivalent to:
```
form-encode(uri-encode(external_id))
```

This PR replaces `URLEncoder.encode(externalIdValue,"UTF-8")` with `URL(null, externalIdValue, null).toString()`